### PR TITLE
fix: 发布文章时行内公式和富文本内容丢失

### DIFF
--- a/src/custom_render.ts
+++ b/src/custom_render.ts
@@ -723,30 +723,38 @@ function remarkSplitLinesToParagraphs() {
             (node: any, index: number | undefined, parent: any) => {
                 if (!parent || index === undefined) return;
 
-                const hasRichChildren = node.children.some(
-                    (child: any) =>
-                        child.type !== "text" && child.type !== "break",
+                const groups: any[][] = [[]];
+
+                for (const child of node.children) {
+                    if (child.type === "break") {
+                        groups.push([]);
+                        continue;
+                    }
+                    if (child.type === "text") {
+                        const parts = child.value.split(/\n/);
+                        for (let i = 0; i < parts.length; i++) {
+                            if (i > 0) groups.push([]);
+                            if (parts[i]) {
+                                groups[groups.length - 1].push({
+                                    type: "text",
+                                    value: parts[i],
+                                });
+                            }
+                        }
+                        continue;
+                    }
+                    groups[groups.length - 1].push(child);
+                }
+
+                const nonEmptyGroups = groups.filter(
+                    (g) => g.length > 0,
                 );
-                if (hasRichChildren) return;
 
-                const text = node.children
-                    .map((child: any) => {
-                        if (child.type === "text") return child.value;
-                        if (child.type === "break") return "\n";
-                        return "";
-                    })
-                    .join("");
+                if (nonEmptyGroups.length <= 1) return;
 
-                const lines = text
-                    .split(/\n+/)
-                    .map((s: string) => s.trim())
-                    .filter(Boolean);
-
-                if (lines.length <= 1) return;
-
-                const newNodes = lines.map((line: string) => ({
+                const newNodes = nonEmptyGroups.map((children) => ({
                     type: "paragraph",
-                    children: [{ type: "text", value: line }],
+                    children,
                 }));
 
                 parent.children.splice(index, 1, ...newNodes);

--- a/src/custom_render.ts
+++ b/src/custom_render.ts
@@ -723,6 +723,12 @@ function remarkSplitLinesToParagraphs() {
             (node: any, index: number | undefined, parent: any) => {
                 if (!parent || index === undefined) return;
 
+                const hasRichChildren = node.children.some(
+                    (child: any) =>
+                        child.type !== "text" && child.type !== "break",
+                );
+                if (hasRichChildren) return;
+
                 const text = node.children
                     .map((child: any) => {
                         if (child.type === "text") return child.value;


### PR DESCRIPTION
## 问题
`remarkSplitLinesToParagraphs` 在处理包含行内公式（`inlineMath`）、粗体（`strong`）、链接（`link`）等富文本子节点的段落时，会将非 `text`/`break` 节点映射为空字符串，导致公式和格式化内容在发布时被丢弃，同时纯文本部分被重复拆分为多个段落。
## 修复
在拆分前检查段落是否包含富文本子节点，如果有则跳过拆分，保留原始段落结构。
## 改动
- `src/custom_render.ts`: 在 `remarkSplitLinesToParagraphs` 中新增 `hasRichChildren` 检查
EOF
)".